### PR TITLE
fix viewport initial scale

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="manifest" href="%PUBLIC_URL%/manifest.webmanifest">
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
   <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>


### PR DESCRIPTION
Without viewport scaling, safari on iOS does not scale the app,
making it hard to use all the elements. See: https://stackoverflow.com/a/22778172

Should be tested on Android devices. Unfortunately, I don't have one around.

P.S. Hola amiguito Matteo tqqj